### PR TITLE
Allow unindexLayer() to accept user-defined bounds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+bower_components

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Leaflet.LayerIndex
 ==================
 
-Efficient spatial index for Leaflet layers. It works recursively 
+Efficient spatial index for Leaflet layers. It works recursively
 for ``L.FeatureGroup`` objects.
 
 Requires the Magnificient [RTree.js](https://github.com/imbcmdth/RTree)
@@ -28,8 +28,19 @@ Usage
         console.log(shown.length + ' objects shown.');
     });
 
+    // remove the spatial index when the layer is unused
+    map.unindexLayer(layer);
 ```
 
+`map.unindexLayer()` function accepts an `options` object as an optional second parameter to defined the bounds of the layer. It could accept:
+
+* `options.bounds`  - a leaflet latLngBounds object
+
+* `options.latlng`  - a leaflet latLng object
+
+* `options.latlngs` - an array of leaflet latLng objects
+
+If no option is provided, the function will use the bounds of the layer's geometry.
 
 ### Using inherited class
 
@@ -37,7 +48,7 @@ Usage
 
     L.IndexedGeoJSON = L.GeoJSON.extend({
         includes: L.LayerIndexMixin,
-        
+
         initialize: function (geojson, options) {
             // Decorate onEachFeature to index layers
             var onEachFeature = function (geojson, layer) {
@@ -46,7 +57,7 @@ Usage
             };
             this._onEachFeature = options.onEachFeature;
             options.onEachFeature = L.Util.bind(onFeatureParse, this);
-            
+
             // Parent initialization
             L.GeoJSON.prototype.initialize.call(this, geojson, options);
         }
@@ -54,7 +65,7 @@ Usage
 
 
     var layer = L.IndexedGeoJSON(data).addTo(map);
-    
+
     var aroundToulouse = layer.searchBuffer(L.latLng([43.60, 1.44]), 0.1);
 
 ```

--- a/README.md
+++ b/README.md
@@ -32,12 +32,9 @@ Usage
     map.unindexLayer(layer);
 ```
 
-`map.unindexLayer()` function accepts an `options` object as an optional second parameter to defined the bounds of the layer. It could accept:
-
+`map.unindexLayer()` function accepts an `options` object as an optional second parameter to define the bounds to be removed from the index. It should have one of the following attributes:
 * `options.bounds`  - a leaflet latLngBounds object
-
 * `options.latlng`  - a leaflet latLng object
-
 * `options.latlngs` - an array of leaflet latLng objects
 
 If no option is provided, the function will use the bounds of the layer's geometry.

--- a/leaflet.layerindex.js
+++ b/leaflet.layerindex.js
@@ -38,8 +38,18 @@ L.LayerIndexMixin = {
         this._rtree.insert(this._rtbounds(bounds), layer);
     },
 
-    unindexLayer: function (layer) {
-        var bounds = this._layerBounds(layer);
+    unindexLayer: function (layer, options) {
+        var bounds;
+        if (options && options.bounds) {
+            bounds = options.bounds;
+        } else if (options && options.latLng) {
+            bounds = new L.LatLngBounds(options.latLng, options.latLng);
+        } else if (options && options.latLngs) {
+            bounds = new L.LatLngBounds(options.latLngs);
+        } else {
+            bounds = this._layerBounds(layer);
+        }
+
         this._rtree.remove(this._rtbounds(bounds), layer);
     },
 

--- a/leaflet.layerindex.js
+++ b/leaflet.layerindex.js
@@ -42,10 +42,10 @@ L.LayerIndexMixin = {
         var bounds;
         if (options && options.bounds) {
             bounds = options.bounds;
-        } else if (options && options.latLng) {
-            bounds = new L.LatLngBounds(options.latLng, options.latLng);
-        } else if (options && options.latLngs) {
-            bounds = new L.LatLngBounds(options.latLngs);
+        } else if (options && options.latlng) {
+            bounds = new L.LatLngBounds(options.latlng, options.latlng);
+        } else if (options && options.latlngs) {
+            bounds = new L.LatLngBounds(options.latlngs);
         } else {
             bounds = this._layerBounds(layer);
         }


### PR DESCRIPTION
This modification allows `unindexLayer()` to accept user-defined bounds, including:

* `options.bounds` - a L.latLngBounds

* `options.latlng` - a L.latLng

* `options.latlngs` - an array of L.latLng

if no option is given, it will use the bounds of the given layer.

My use case of this function is to remove the layer index from its original location after it's moved or edited by `leaflet.draw`.