### PR TITLE
Update docs on inherited class to support remove

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ If no option is provided, the function will use the bounds of the layer's geomet
 
             // Parent initialization
             L.GeoJSON.prototype.initialize.call(this, geojson, options);
+        },
+
+        removeLayer: function (layer) {
+          if (this.hasLayer(layer)) {
+            this.unindexLayer(layer)
+          }
+          return window.L.GeoJSON.prototype.removeLayer.call(this, layer)
         }
     });
 


### PR DESCRIPTION
If you need to use `removeLayer` or `clearLayers` you'll need this override to ensure layers are unindexed, otherwise they will remain on the map.

See issue https://github.com/makinacorpus/Leaflet.LayerIndex/issues/6